### PR TITLE
Add the pox to skip continuous integration

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: "!(contains(github.event.head_commit.message, 'skip ci')||contains(github.event.head_commit.message, 'ci skip')||contains(github.event.head_commit.message, 'skip-ci')||contains(github.event.head_commit.message, 'ci-skip')||contains(github.event.head_commit.message, 'skip_ci')||contains(github.event.head_commit.message, 'ci_skip')"
+    if: "!(contains(github.event.head_commit.message, 'skip ci')||contains(github.event.head_commit.message, 'ci skip')||contains(github.event.head_commit.message, 'skip-ci')||contains(github.event.head_commit.message, 'ci-skip')||contains(github.event.head_commit.message, 'skip_ci')||contains(github.event.head_commit.message, 'ci_skip'))"
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,7 +10,7 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
-    if: "!(contains(github.event.head_commit.message, 'skip ci')||contains(github.event.head_commit.message, 'ci skip'))||contains(github.event.head_commit.message, 'skip-ci'))||contains(github.event.head_commit.message, 'ci-skip'))||contains(github.event.head_commit.message, 'skip_ci'))||contains(github.event.head_commit.message, 'ci_skip'))"
+    if: "!(contains(github.event.head_commit.message, 'skip ci')||contains(github.event.head_commit.message, 'ci skip')||contains(github.event.head_commit.message, 'skip-ci')||contains(github.event.head_commit.message, 'ci-skip')||contains(github.event.head_commit.message, 'skip_ci')||contains(github.event.head_commit.message, 'ci_skip')"
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -10,6 +10,7 @@ name: R-CMD-check
 
 jobs:
   R-CMD-check:
+    if: "!(contains(github.event.head_commit.message, 'skip ci')||contains(github.event.head_commit.message, 'ci skip'))||contains(github.event.head_commit.message, 'skip-ci'))||contains(github.event.head_commit.message, 'ci-skip'))||contains(github.event.head_commit.message, 'skip_ci'))||contains(github.event.head_commit.message, 'ci_skip'))"
     runs-on: ${{ matrix.config.os }}
 
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})


### PR DESCRIPTION
We do not need to run CI if we are simply updating docs or descriptions so this PR adds the possibility to skip CI if the commit message contains one of {"skip ci", "ci skip", "skip-ci", "ci-skip", "skip_ci", "ci_skip"}

The yaml code is pretty ugly but I don't know how to fix that (i.e. move the if clause to multiple lines) 